### PR TITLE
Add support for recursive directory deletion to S3 client

### DIFF
--- a/s3fs/js/events.js
+++ b/s3fs/js/events.js
@@ -7,6 +7,7 @@
 'use strict';
 
 var util = require('../../shared/util');
+var getError = require('./errors');
 
 /**
  * Fetches the metadata associated with the file at the given path from the
@@ -172,8 +173,6 @@ var deleteFile = function(path, onSuccess, onError) {
  */
 var deleteRecursive = function(entryPath, onSuccess, onError) {
   onReadDirectoryRequested({directoryPath: entryPath}, function(list) {
-    console.log(list);
-
     var parameters = s3fs.parameters({
       Delete: list.map(function(item) {
         return {Key: entryPath + '/' + item.name};
@@ -182,7 +181,6 @@ var deleteRecursive = function(entryPath, onSuccess, onError) {
 
     s3fs.s3.deleteObjects(parameters, function(error) {
       if (error) {
-        console.log(error);
         onError(error);
       } else {
         onSuccess();

--- a/s3fs/package.json
+++ b/s3fs/package.json
@@ -26,5 +26,8 @@
     "test": "grunt test"
   },
   "author": "Giles Lavelle <lavelle@chromium.org>",
-  "license": "BSD"
+  "license": "BSD",
+  "dependencies": {
+    "async": "^0.9.0"
+  }
 }

--- a/s3fs/package.json
+++ b/s3fs/package.json
@@ -20,14 +20,12 @@
     "karma-mocha": "^0.1.9",
     "load-grunt-tasks": "^0.6.0",
     "mocha": "^1.21.4",
-    "grunt-jsonlint": "^1.0.4"
+    "grunt-jsonlint": "^1.0.4",
+    "async": "^0.9.0"
   },
   "scripts": {
     "test": "grunt test"
   },
   "author": "Giles Lavelle <lavelle@chromium.org>",
-  "license": "BSD",
-  "dependencies": {
-    "async": "^0.9.0"
-  }
+  "license": "BSD"
 }

--- a/s3fs/test/spec/s3mock.js
+++ b/s3fs/test/spec/s3mock.js
@@ -6,6 +6,8 @@
 
 'use strict';
 
+var async = require('async');
+
 var WebDAVFS = require('../../../webdavfs/js/wdfs');
 /**
  * Mocks the parts of the official AWS JavaScript SDK that are used by the S3
@@ -232,6 +234,35 @@ S3.prototype.copyObject = function(parameters, callback) {
     },
     onError: function(error) {
       callback(error, null);
+    }
+  });
+};
+
+/**
+ * Implements the S3 deleteObjects method in terms of WebDAVFS's deleteEntry.
+ * See: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#deleteObjects-property
+ *
+ * @param {Object} parameters The S3 API parameters for this function.
+ * @param {function} callback The callback to be executed when the operation
+ *     finishes.
+ */
+S3.prototype.deleteObjects = function(parameters, callback) {
+  var wdfs = this.wdfs;
+
+  async.eachSeries(parameters.Delete, function(item, eachCallback) {
+    console.log(item.Key);
+
+    wdfs.deleteEntry({
+      path: item.Key.substring(1),
+      onSuccess: eachCallback,
+      onError: eachCallback
+    });
+  }, function(error) {
+    if (error) {
+      callback(error, null);
+    }
+    else {
+      callback(null, {});
     }
   });
 };

--- a/s3fs/test/spec/s3mock.js
+++ b/s3fs/test/spec/s3mock.js
@@ -159,7 +159,17 @@ S3.prototype.headObject = function(parameters, callback) {
   this.wdfs.getMetadata({
     path: path,
     onSuccess: function(response) {
-      var error = null;
+      var error;
+      if (response.isDirectory) {
+        // headObject only applies to files.
+        // error = new Error();
+        // error.code = 'NoSuchKey';
+        error = 'NOT_FOUND';
+        callback(error, null);
+        return;
+      }
+
+      error = null;
 
       var data = {
         ContentLength: response.size,
@@ -250,11 +260,11 @@ S3.prototype.deleteObjects = function(parameters, callback) {
   var wdfs = this.wdfs;
 
   async.eachSeries(parameters.Delete, function(item, eachCallback) {
-    console.log(item.Key);
-
     wdfs.deleteEntry({
       path: item.Key.substring(1),
-      onSuccess: eachCallback,
+      onSuccess: function() {
+        eachCallback();
+      },
       onError: eachCallback
     });
   }, function(error) {

--- a/shared_tests/onDeleteEntryRequested.js
+++ b/shared_tests/onDeleteEntryRequested.js
@@ -40,10 +40,6 @@ module.exports = function(fs, onDeleteEntryRequested, onGetMetadataRequested) {
       }, onError);
     });
 
-    if (!window[fs].supportsRecursive) {
-      return;
-    }
-
     it('should remove an empty directory without needing the recursive flag',
       function(done) {
         var statOptions = {
@@ -89,6 +85,7 @@ module.exports = function(fs, onDeleteEntryRequested, onGetMetadataRequested) {
         };
 
         var onError = function(error) {
+          console.log(error.documentElement);
           throw new Error(error);
         };
 

--- a/shared_tests/onDeleteEntryRequested.js
+++ b/shared_tests/onDeleteEntryRequested.js
@@ -89,7 +89,6 @@ module.exports = function(fs, onDeleteEntryRequested, onGetMetadataRequested) {
         };
 
         var postDeleteSuccess = function(metadata) {
-          console.log(metadata);
           throw new Error('Delete operation failed to remove directory.');
         };
 

--- a/shared_tests/onDeleteEntryRequested.js
+++ b/shared_tests/onDeleteEntryRequested.js
@@ -85,11 +85,11 @@ module.exports = function(fs, onDeleteEntryRequested, onGetMetadataRequested) {
         };
 
         var onError = function(error) {
-          console.log(error.documentElement);
           throw new Error(error);
         };
 
-        var postDeleteSuccess = function() {
+        var postDeleteSuccess = function(metadata) {
+          console.log(metadata);
           throw new Error('Delete operation failed to remove directory.');
         };
 

--- a/testserver/package.json
+++ b/testserver/package.json
@@ -11,6 +11,7 @@
   "license": "BSD",
   "dependencies": {
     "jsDAV": "^0.3.2",
-    "mock-fs": "^2.3.1"
+    "mock-fs": "^2.3.1",
+    "optimist": "^0.6.1"
   }
 }

--- a/testserver/server.js
+++ b/testserver/server.js
@@ -71,6 +71,10 @@ var rebuilder = plugin.extend({
     handler.addEventListener('beforeMethod', function(event, method, file) {
       if (method === 'GET' && file === 'reset') {
         mockfs(structure);
+        console.log('\nResetting filesystem contents');
+      }
+      else {
+        console.log(method + ' ' + file);
       }
       event.next();
     });

--- a/testserver/server.js
+++ b/testserver/server.js
@@ -18,13 +18,17 @@ var util = require("jsDAV/lib/shared/util");
 var plugin = require("jsDAV/lib/DAV/plugin");
 var mockfs = require('mock-fs');
 var config = require('./config');
+var argv = require('optimist')
+  .alias('v', 'verbosity')
+  .default('v', 0)
+  .argv;
 
-var argv = process.argv.slice(2);
+// Verbosity levels:
+// 0 (default): no logging
+// 1: logs incoming request type and target file/directory
+// 2: enables JSDAV internal debug mode which logs a ton of stuff
 
-var flags = ['--debug', '-d'];
-
-// Enable debug mode if the command-line flag is set.
-if (argv.length > 0 && flags.indexOf(argv[0]) !== -1) {
+if (argv.verbosity >= 2) {
   jsdav.debugMode = true;
 }
 
@@ -71,10 +75,14 @@ var rebuilder = plugin.extend({
     handler.addEventListener('beforeMethod', function(event, method, file) {
       if (method === 'GET' && file === 'reset') {
         mockfs(structure);
-        console.log('\nResetting filesystem contents');
+        if (argv.verbosity >= 1) {
+          console.log('\nResetting filesystem contents');
+        }
       }
       else {
-        console.log(method + ' ' + file);
+        if (argv.verbosity >= 1) {
+          console.log(method + ' ' + file);
+        }
       }
       event.next();
     });

--- a/webdavfs/js/wdfs.js
+++ b/webdavfs/js/wdfs.js
@@ -96,7 +96,6 @@ WebDAVFS.prototype.writeFile = function(options) {
  */
 WebDAVFS.prototype.deleteEntry = function(options) {
   var url = this.url + options.path;
-  console.log(url);
   var headers = null;
 
   client.delete(url, headers, options.onSuccess, options.onError);

--- a/webdavfs/js/wdfs.js
+++ b/webdavfs/js/wdfs.js
@@ -96,6 +96,7 @@ WebDAVFS.prototype.writeFile = function(options) {
  */
 WebDAVFS.prototype.deleteEntry = function(options) {
   var url = this.url + options.path;
+  console.log(url);
   var headers = null;
 
   client.delete(url, headers, options.onSuccess, options.onError);


### PR DESCRIPTION
This currently doesn't pass the tests, but that's because of problems with the mock S3 client, not the implementation. When a solution to #113 is found, we should be able to merge this, and then recursive copy/move should be pretty easy.
