### PR TITLE
Remove trailing comma in package.json

### DIFF
--- a/templatefs/package.json
+++ b/templatefs/package.json
@@ -18,5 +18,5 @@
     "test": "grunt test"
   },
   "author": "{{ author }}",
-  "license": "BSD",
+  "license": "BSD"
 }


### PR DESCRIPTION
Causes grunt to fail on new filesystem creation.
